### PR TITLE
[FIX] l10n_latam_check: own check liquidity lines in foreign currency

### DIFF
--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -178,21 +178,27 @@ class AccountPayment(models.Model):
         # if only one check we don't create the split line, we add same data on liquidity line ?
 
         if self.payment_method_code == 'own_checks' and self.payment_type == 'outbound' and len(self.l10n_latam_new_check_ids) >= 1 and check_ids:
-            liquidity_balance_total = 0.0
+            company_currency = self.company_id.currency_id
+            amount_currency_total = 0.0
+            balance_total = 0.0
             line_vals = []
             for check in check_ids:
                 if check == self.l10n_latam_new_check_ids[-1]:
-                    liquidity_balance = self.currency_id.round(abs(default_values['balance']) - liquidity_balance_total)
+                    # last check absorbs rounding: close each column against its own total
+                    liquidity_amount_currency = self.currency_id.round(abs(default_values['amount_currency']) - amount_currency_total)
+                    liquidity_balance = company_currency.round(abs(default_values['balance']) - balance_total)
                 else:
-                    liquidity_balance = self.currency_id.round(check.amount)
-                    liquidity_balance_total += liquidity_balance
+                    # check.amount is expressed in the payment currency (check.currency_id)
+                    liquidity_amount_currency = self.currency_id.round(check.amount)
+                    liquidity_balance = self.currency_id._convert(
+                        liquidity_amount_currency,
+                        company_currency,
+                        self.company_id,
+                        self.date
+                    )
+                    amount_currency_total += liquidity_amount_currency
+                    balance_total += liquidity_balance
 
-                liquidity_amount_currency = self.company_id.currency_id._convert(
-                    liquidity_balance,
-                    self.currency_id,
-                    self.company_id,
-                    self.date
-                )
                 line_vals.append({
                     'name': _(
                         'Check %(check_number)s - %(suffix)s',

--- a/addons/l10n_latam_check/tests/test_own_checks.py
+++ b/addons/l10n_latam_check/tests/test_own_checks.py
@@ -92,3 +92,47 @@ class TestOwnChecks(L10nLatamCheckTest):
         })
         payment.action_post()
         self.assertEqual(payment.amount, 120)
+
+    def test_own_check_multicurrency_liquidity_amounts(self):
+        """ Own checks issued in a currency different from the company one. Each
+        check liquidity line must keep the check nominal in amount_currency (the
+        payment currency) and its conversion to company currency in balance. The
+        issue only shows up when the rate is not 1:1, so we set a controlled one. """
+        company = self.company_data_3['company']
+        company_currency = company.currency_id
+        foreign_currency = self.env.ref('base.EUR')
+        foreign_currency.active = True
+        self.assertNotEqual(company_currency, foreign_currency)
+        self.env['res.currency.rate'].create({
+            'name': '2016-01-01',
+            'currency_id': foreign_currency.id,
+            'company_id': company.id,
+            'rate': 4.0,
+        })
+        payment_method_line = self.bank_journal._get_available_payment_method_lines('outbound').filtered_domain([('code', '=', 'own_checks')])[:1]
+        payment = self.env['account.payment'].create({
+            'payment_type': 'outbound',
+            'partner_id': self.partner_a.id,
+            'journal_id': self.bank_journal.id,
+            'currency_id': foreign_currency.id,
+            'date': fields.Date.today(),
+            'payment_method_line_id': payment_method_line.id,
+            'l10n_latam_new_check_ids': [
+                Command.create({'payment_date': fields.Date.today(), 'amount': 20}),
+                Command.create({'payment_date': fields.Date.today(), 'amount': 30}),
+                Command.create({'payment_date': fields.Date.today(), 'amount': 70}),
+            ]
+        })
+        payment.action_post()
+        self.assertEqual(payment.amount, 120)
+
+        for check in payment.l10n_latam_new_check_ids:
+            line = check.outstanding_line_id
+            self.assertEqual(
+                abs(line.amount_currency), check.amount,
+                "Check liquidity line must hold the nominal in the payment currency")
+            expected_balance = foreign_currency._convert(
+                check.amount, company_currency, company, payment.date)
+            self.assertEqual(
+                abs(line.balance), expected_balance,
+                "Check liquidity line balance must be the nominal converted to company currency")


### PR DESCRIPTION
## Problem
In the own checks branch of `_prepare_move_liquidity_lines`, the split liquidity lines mix up amounts when the payment/journal currency differs from the company currency. The check nominal — expressed in the payment currency — was written into `balance` (company currency) and `amount_currency` was back-computed by converting in the wrong direction (company → payment), so `amount_currency` ended up as `nominal / rate`. With more than one check, the last one absorbed the imbalance, producing a move amount far above the check face value.

Only reproducible when the exchange rate is not 1:1 (the existing 3-line test uses a 1:1 rate and does not assert the per-line amounts, so it did not catch it).

## Fix
- `amount_currency` = check nominal, in the payment currency (direct, no conversion).
- `balance` = nominal converted payment → company currency (same direction the core uses in `_prepare_move_lines_per_type`).
- The last check closes each column against its own grand total (`amount_currency` vs `default_values['amount_currency']`, `balance` vs `default_values['balance']`).
- Backward compatible: with a 1:1 rate `_convert` is the identity, so the result is unchanged for same-currency payments.

## Test
Adds `test_own_check_multicurrency_liquidity_amounts`: an own check payment in a foreign currency with a controlled rate ≠ 1, asserting that each liquidity line keeps the nominal in `amount_currency` and its conversion in `balance`. Fails before the fix (`amount_currency` came out as `nominal / rate`), passes after.

Correction on top of the multiple-liquidity-lines work — meant to be merged into that branch so it flows into odoo/odoo#248296.